### PR TITLE
Fix DOMPDF blank second page and last page margins

### DIFF
--- a/pdfhtml/index.php
+++ b/pdfhtml/index.php
@@ -22,7 +22,7 @@
         }
 
         @page :last {
-            margin: 0 !important;
+            margin: 0;
         }
 
         body {
@@ -87,11 +87,18 @@
             background-size: cover;
             background-position: center;
             position: relative;
+            page-break-after: always;
+        }
+
+        .last-page {
+            margin: 0;
+            padding: 0;
+            page-break-before: always;
         }
 
         .last-page img {
             width: 100%;
-            height: 100vh;
+            height: 297mm;
             object-fit: cover;
             display: block;
             margin: 0;
@@ -246,7 +253,6 @@
 
         </div>
     </div>
-     <div class="page-break"></div>
 
     <!-- DESKTOP RESIDENTIAL VALUATION REPORT -->
     <div class="table-report">


### PR DESCRIPTION
## Summary
- avoid blank second page by removing extra page-break and adding explicit break after cover page
- remove margins from the final page using `@page :last` and zero padding on the last-page container
- size last-page image to fill page

## Testing
- `php -l pdfhtml/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae9b87020c83248aea8006de9141e0