### PR TITLE
Remove top margin for PDF last page

### DIFF
--- a/pdfhtml/index.php
+++ b/pdfhtml/index.php
@@ -21,6 +21,14 @@
             margin: 0 !important;
         }
 
+        @page last-page {
+            /* Remove all margins on the final page to allow a full-bleed image */
+            margin-top: 0;
+            margin-right: 0;
+            margin-bottom: 0;
+            margin-left: 0;
+        }
+
         body {
             font-family: "Roboto", sans-serif;
             font-size: 14px;
@@ -87,7 +95,10 @@
         }
 
         .last-page {
+            page: last-page;
             page-break-before: always;
+            margin: 0;
+            padding: 0;
         }
 
         .last-page img {


### PR DESCRIPTION
## Summary
- Explicitly zero out margins on the final PDF page using a named `@page` rule
- Clear margin and padding on the last-page container for a full-bleed image

## Testing
- `php -l pdfhtml/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68aebf011e2c83248ae3bb0e561124b1